### PR TITLE
Changing the next/previous artboard Shortcut

### DIFF
--- a/Artboard-Tools.sketchplugin/Contents/Sketch/manifest.json
+++ b/Artboard-Tools.sketchplugin/Contents/Sketch/manifest.json
@@ -33,14 +33,14 @@
     {
       "script" : "ArtboardTools.cocoascript",
       "handler": "select_prev",
-      "shortcut" : "command shift [",
+      "shortcut" : "command shift ]",
       "name" : "Select Previous Artboard",
       "identifier" : "901_select_prev_artboard"
     },
     {
       "script" : "ArtboardTools.cocoascript",
       "handler": "select_next",
-      "shortcut" : "command shift ]",
+      "shortcut" : "command shift [",
       "name" : "Select Next Artboard",
       "identifier" : "902_select_next_artboard"
     },


### PR DESCRIPTION
If you select the artboard that is at the top of your artboard list, it makes more sense to go to the next item in the list with the key to the right